### PR TITLE
Add IDX button in README

### DIFF
--- a/README.md
+++ b/README.md
@@ -2,5 +2,14 @@
 
 Flappy bird in JS. Used to test Project IDX - https://idx.dev
 
+<a href="https://idx.google.com/new-git?url=https://github.com/prakhar1989/flappy-bird.git&nix=false&type=web">
+  <img
+    alt="Open in Monospace"
+    src="https://www.gstatic.com/monospace/230815/openinprojectidx.png"
+    width="120"
+    height="24"
+  />
+</a>
+
 ![image](https://github.com/prakhar1989/flappy-bird/assets/649249/db25551d-0a5e-44a6-93f9-aeb96d26db5b)
 


### PR DESCRIPTION
Add the `Open in Project IDX button` in ReadME so we can directly click on that button to create a workspace for the flappy-bird web app in IDX.
We may need to wait for my CL to be pushed to prod, then this button should work fine.
Preview for README: https://screenshot.googleplex.com/5eTwdrNPDckWsTm.